### PR TITLE
Fix wind speed index: use Wind Avg (index 2) instead of Wind Lull (in…

### DIFF
--- a/bin/user/tempestWS.py
+++ b/bin/user/tempestWS.py
@@ -187,7 +187,7 @@ class tempestWS(weewx.drivers.AbstractDevice):
                     loop_packet['lightening_strike_count'] = mqtt_data[15]
                     loop_packet['windDir'] = mqtt_data[4]
                     loop_packet['windGust'] = mqtt_data[3]
-                    loop_packet['windSpeed'] = mqtt_data[1]
+                    loop_packet['windSpeed'] = mqtt_data[2]
                 elif resp['type'] == 'rapid_wind':
                     mqtt_data = resp['ob']
                     loop_packet['dateTime'] = mqtt_data[0]


### PR DESCRIPTION
…dex 1)

Per Weatherflow obs_st API: index 1=Wind Lull, index 2=Wind Avg, index 3=Wind Gust. windSpeed should represent current/average wind, not the minimum.