### PR TITLE
Add missing continue after null websocket response

### DIFF
--- a/bin/user/tempestWS.py
+++ b/bin/user/tempestWS.py
@@ -153,10 +153,11 @@ class tempestWS(weewx.drivers.AbstractDevice):
 
             # First, check to see if the connection died and retry if it did
             try:
-                raw_resp = self.ws.recv()
-                if raw_resp == "":
-                    logerr("Caught a null response in the genLoopPackets loop.")
-            except (WebSocketConnectionClosedException, WebSocketTimeoutException) as e:
+                    raw_resp = self.ws.recv()
+                    if raw_resp == "":
+                        logerr("Caught a null response in the genLoopPackets loop.")
+                        continue
+                except (WebSocketConnectionClosedException, WebSocketTimeoutException) as e:
                 logerr("Caught a " + str(type(e)) + ", attempting to reconnect!  Try " +str(retries))
                 time.sleep(self._reconnect_sleep_interval)
                 self.ws.connect(self._ws_uri)


### PR DESCRIPTION
When websocket returns empty string, the code logged but didn't skip the iteration. Execution fell through to json.loads('') which raised JSONDecodeError.