### PR TITLE
Fix config key mismatch: support both restart_sleep_interval and reco…

### DIFF
--- a/bin/user/tempestWS.py
+++ b/bin/user/tempestWS.py
@@ -118,7 +118,9 @@ class tempestWS(weewx.drivers.AbstractDevice):
         self._tempest_device_id = str(cfg_dict.get('tempest_device_id'))
         self._tempest_station_id = str(cfg_dict.get('tempest_station_id'))
         self._tempest_ws_endpoint = str(cfg_dict.get('tempest_ws_endpoint'))
-        self._reconnect_sleep_interval = int(cfg_dict.get('reconnect_sleep_interval'))
+        # Support both reconnect_sleep_interval and restart_sleep_interval for backward compatibility
+        sleep_interval = cfg_dict.get('reconnect_sleep_interval') or cfg_dict.get('restart_sleep_interval')
+        self._reconnect_sleep_interval = int(sleep_interval) if sleep_interval else 20
         self._ws_uri=self._tempest_ws_endpoint + '?token=' + self._personal_token
 
         # Connect to the websocket and issue the starting commands for rapid and listen packets.


### PR DESCRIPTION
…nnect_sleep_interval

The README documents restart_sleep_interval but the code only reads reconnect_sleep_interval. Users following the README get ValueError on startup.

This fix supports both config keys for backward compatibility and defaults to 20 seconds if neither is set.