### PR TITLE
Fix windSpeed mapped to wrong obs_st index

### DIFF
--- a/bin/user/tempestWS.py
+++ b/bin/user/tempestWS.py
@@ -187,7 +187,7 @@ class tempestWS(weewx.drivers.AbstractDevice):
                     loop_packet['lightening_strike_count'] = mqtt_data[15]
                     loop_packet['windDir'] = mqtt_data[4]
                     loop_packet['windGust'] = mqtt_data[3]
-                    loop_packet['windSpeed'] = mqtt_data[1]
+                    loop_packet['windSpeed'] = mqtt_data[2]
                 elif resp['type'] == 'rapid_wind':
                     mqtt_data = resp['ob']
                     loop_packet['dateTime'] = mqtt_data[0]


### PR DESCRIPTION
## Summary
- `windSpeed` in the `obs_st` handler was mapped to `mqtt_data[1]`, which is **wind_lull** (minimum 3-second average), not wind_avg
- - Per the WeatherFlow Tempest WebSocket API, the correct indices are: `[1]` = wind_lull, `[2]` = wind_avg, `[3]` = wind_gust
- - Changed to `mqtt_data[2]` so the driver reports the correct average wind speed
## Test plan
- [ ] Verify `obs_st` packets now report wind_avg (index 2) as `windSpeed`
- [ ] - [ ] Confirm `rapid_wind` windSpeed mapping (index 1) is unchanged — rapid_wind has a different array format where index 1 is correctly the wind speed
- [ ] - [ ] Compare reported wind speed values against the Tempest app to validate accuracy