### PR TITLE
Fix empty WebSocket response falling through to json.loads

### DIFF
--- a/bin/user/tempestWS.py
+++ b/bin/user/tempestWS.py
@@ -156,6 +156,7 @@ class tempestWS(weewx.drivers.AbstractDevice):
                 raw_resp = self.ws.recv()
                 if raw_resp == "":
                     logerr("Caught a null response in the genLoopPackets loop.")
+                    continue
             except (WebSocketConnectionClosedException, WebSocketTimeoutException) as e:
                 logerr("Caught a " + str(type(e)) + ", attempting to reconnect!  Try " +str(retries))
                 time.sleep(self._reconnect_sleep_interval)


### PR DESCRIPTION
## Summary
- When an empty string is received from the WebSocket, the code logged an error but did not continue the loop
- Execution fell through to json.loads(""), which raises a JSONDecodeError
- While the subsequent try/except catches that error, it generates a misleading decode error log message and wastes a loop iteration
- Added a continue statement after the empty response check to skip directly to the next iteration

## Test plan
- [ ] Verify that empty WebSocket responses are handled cleanly with a single error log
- [ ] Confirm no JSONDecodeError log appears after an empty response
- [ ] Validate that the driver continues to receive and process subsequent valid packets after an empty response